### PR TITLE
Fix string ownership in Loop Labels example

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ func makeNumericSkewer String {
         }
     }
 
-    return skewer
+    return skewer.commit()
 }
 
 func makeAlphabetSkewer String {
@@ -303,7 +303,7 @@ func makeAlphabetSkewer String {
         skewer.append("-")
     }
 
-    return skewer
+    return skewer.commit()
 }
 ```
 


### PR DESCRIPTION
`print(makeNumericSkewer())` and `print(makeAlphabetSkewer())` is printing garbage. The returned string is still owned by those function and got freed at the end of the scope.